### PR TITLE
Don't get archived channel

### DIFF
--- a/app/client/services/company.service.js
+++ b/app/client/services/company.service.js
@@ -23,7 +23,7 @@ var CompanyService = Service.extend({
 
     if (this.scope.company.slack) {
       // Get channels
-      this.scope.$http.get('https://slack.com/api/channels.list?token=' + this.scope.company.slack)
+      this.scope.$http.get('https://slack.com/api/channels.list?exclude_archived=1&token=' + this.scope.company.slack)
         .success(function (data) {
           this.scope.channels = data.channels;
           this.scope.defaultChannel = this.scope.channels[0];


### PR DESCRIPTION
It's useless to retrieve archived channels since nobody will see the posted message.

Related Slack doc: https://api.slack.com/methods/channels.list